### PR TITLE
Improve prompts in dummy executables

### DIFF
--- a/dummy_bin/atom_cutting.py
+++ b/dummy_bin/atom_cutting.py
@@ -22,6 +22,11 @@ def main() -> None:
     parser.add_argument("--input_type", type=int, choices=[1, 2], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy atom_cutting executable. You will be asked for the wavefunction "
+        "input type. Press Enter to accept the default shown in brackets."
+    )
+
     input_type = ask_input(
         "Input type (1=charge, 2=orbitals): ",
         default=2,

--- a/dummy_bin/ome.py
+++ b/dummy_bin/ome.py
@@ -22,6 +22,11 @@ def main() -> None:
     parser.add_argument("--orbital_suffix", default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy ome executable. You will be asked for the orbital file suffix. "
+        "Press Enter to accept the default shown in brackets."
+    )
+
     suffix = ask_input(
         "Orbital file suffix: ",
         default="cutatom_check",

--- a/dummy_bin/shg.py
+++ b/dummy_bin/shg.py
@@ -31,6 +31,11 @@ def main() -> None:
     parser.add_argument("--energy_range", type=int, choices=[0, 1, 2], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy SHG executable. You will be prompted for several parameters. "
+        "Press Enter at any prompt to accept the displayed default value."
+    )
+
     scissors = ask_input("Scissors: ", 0.0, args.scissors)
     direction = ask_input("Direction: ", "123", args.direction)
     band_resolved = ask_input("Band resolved (0/1): ", 0, args.band_resolved)

--- a/dummy_bin/weighted_den.py
+++ b/dummy_bin/weighted_den.py
@@ -22,6 +22,12 @@ def main() -> None:
     parser.add_argument("--output_format", type=int, choices=[1, 2, 3], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy weighted_den.x executable. You will be prompted for the output "
+        "file format. Enter 1 for .pot, 2 for .check, or 3 for .grd. Press "
+        "Enter to accept the default."
+    )
+
     fmt = ask_input(
         "Output format (1=pot,2=check,3=grd): ",
         default=3,

--- a/src/castepkit/dummy_bin/atom_cutting.py
+++ b/src/castepkit/dummy_bin/atom_cutting.py
@@ -22,6 +22,11 @@ def main() -> None:
     parser.add_argument("--input_type", type=int, choices=[1, 2], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy atom_cutting executable. You will be asked for the wavefunction "
+        "input type. Press Enter to accept the default shown in brackets."
+    )
+
     input_type = ask_input(
         "Input type (1=charge, 2=orbitals): ",
         default=2,

--- a/src/castepkit/dummy_bin/ome.py
+++ b/src/castepkit/dummy_bin/ome.py
@@ -22,6 +22,11 @@ def main() -> None:
     parser.add_argument("--orbital_suffix", default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy ome executable. You will be asked for the orbital file suffix. "
+        "Press Enter to accept the default shown in brackets."
+    )
+
     suffix = ask_input(
         "Orbital file suffix: ",
         default="cutatom_check",

--- a/src/castepkit/dummy_bin/shg.py
+++ b/src/castepkit/dummy_bin/shg.py
@@ -31,6 +31,11 @@ def main() -> None:
     parser.add_argument("--energy_range", type=int, choices=[0, 1, 2], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy SHG executable. You will be prompted for several parameters. "
+        "Press Enter at any prompt to accept the displayed default value."
+    )
+
     scissors = ask_input("Scissors: ", 0.0, args.scissors)
     direction = ask_input("Direction: ", "123", args.direction)
     band_resolved = ask_input("Band resolved (0/1): ", 0, args.band_resolved)

--- a/src/castepkit/dummy_bin/weighted_den.py
+++ b/src/castepkit/dummy_bin/weighted_den.py
@@ -22,6 +22,12 @@ def main() -> None:
     parser.add_argument("--output_format", type=int, choices=[1, 2, 3], default=None)
     args = parser.parse_args()
 
+    print(
+        "Dummy weighted_den.x executable. You will be prompted for the output "
+        "file format. Enter 1 for .pot, 2 for .check, or 3 for .grd. Press "
+        "Enter to accept the default."
+    )
+
     fmt = ask_input(
         "Output format (1=pot,2=check,3=grd): ",
         default=3,


### PR DESCRIPTION
## Summary
- add instructions to `atom_cutting.py`, `ome.py`, `shg.py`, and `weighted_den.py` dummy executables

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850defd74008325912241262491822f