### PR TITLE
Improve switch defaults and indexing

### DIFF
--- a/dummy_bin/atom_cutting.py
+++ b/dummy_bin/atom_cutting.py
@@ -27,7 +27,7 @@ def main() -> None:
         "input type. Press Enter to accept the default shown in brackets."
     )
 
-    input_type = ask_input(
+    _ = ask_input(
         "Input type (1=charge, 2=orbitals): ",
         default=2,
         cli_value=args.input_type,

--- a/dummy_bin/ome.py
+++ b/dummy_bin/ome.py
@@ -27,7 +27,7 @@ def main() -> None:
         "Press Enter to accept the default shown in brackets."
     )
 
-    suffix = ask_input(
+    _ = ask_input(
         "Orbital file suffix: ",
         default="cutatom_check",
         cli_value=args.orbital_suffix,

--- a/dummy_bin/shg.py
+++ b/dummy_bin/shg.py
@@ -36,14 +36,14 @@ def main() -> None:
         "Press Enter at any prompt to accept the displayed default value."
     )
 
-    scissors = ask_input("Scissors: ", 0.0, args.scissors)
+    _ = ask_input("Scissors: ", 0.0, args.scissors)
     direction = ask_input("Direction: ", "123", args.direction)
     band_resolved = ask_input("Band resolved (0/1): ", 0, args.band_resolved)
-    rank_number = ask_input("Rank number: ", 0, args.rank_number)
-    unit = ask_input("Unit (0=pm/V,1=esu): ", 0, args.unit)
-    output_level = ask_input("Output level (0/1): ", 0, args.output_level)
-    is_metal = ask_input("Is metal (1/2): ", 2, args.is_metal)
-    energy_range = ask_input("Energy range (0/1/2): ", 0, args.energy_range)
+    _ = ask_input("Rank number: ", 0, args.rank_number)
+    _ = ask_input("Unit (0=pm/V,1=esu): ", 0, args.unit)
+    _ = ask_input("Output level (0/1): ", 0, args.output_level)
+    _ = ask_input("Is metal (1/2): ", 2, args.is_metal)
+    _ = ask_input("Energy range (0/1/2): ", 0, args.energy_range)
 
     prefix = args.prefix
 

--- a/src/castepkit/dummy_bin/atom_cutting.py
+++ b/src/castepkit/dummy_bin/atom_cutting.py
@@ -27,7 +27,7 @@ def main() -> None:
         "input type. Press Enter to accept the default shown in brackets."
     )
 
-    input_type = ask_input(
+    _ = ask_input(
         "Input type (1=charge, 2=orbitals): ",
         default=2,
         cli_value=args.input_type,

--- a/src/castepkit/dummy_bin/ome.py
+++ b/src/castepkit/dummy_bin/ome.py
@@ -27,7 +27,7 @@ def main() -> None:
         "Press Enter to accept the default shown in brackets."
     )
 
-    suffix = ask_input(
+    _ = ask_input(
         "Orbital file suffix: ",
         default="cutatom_check",
         cli_value=args.orbital_suffix,

--- a/src/castepkit/dummy_bin/shg.py
+++ b/src/castepkit/dummy_bin/shg.py
@@ -36,14 +36,14 @@ def main() -> None:
         "Press Enter at any prompt to accept the displayed default value."
     )
 
-    scissors = ask_input("Scissors: ", 0.0, args.scissors)
+    _ = ask_input("Scissors: ", 0.0, args.scissors)
     direction = ask_input("Direction: ", "123", args.direction)
     band_resolved = ask_input("Band resolved (0/1): ", 0, args.band_resolved)
-    rank_number = ask_input("Rank number: ", 0, args.rank_number)
-    unit = ask_input("Unit (0=pm/V,1=esu): ", 0, args.unit)
-    output_level = ask_input("Output level (0/1): ", 0, args.output_level)
-    is_metal = ask_input("Is metal (1/2): ", 2, args.is_metal)
-    energy_range = ask_input("Energy range (0/1/2): ", 0, args.energy_range)
+    _ = ask_input("Rank number: ", 0, args.rank_number)
+    _ = ask_input("Unit (0=pm/V,1=esu): ", 0, args.unit)
+    _ = ask_input("Output level (0/1): ", 0, args.output_level)
+    _ = ask_input("Is metal (1/2): ", 2, args.is_metal)
+    _ = ask_input("Energy range (0/1/2): ", 0, args.energy_range)
 
     prefix = args.prefix
 

--- a/src/castepkit/scripts/create_switch.py
+++ b/src/castepkit/scripts/create_switch.py
@@ -11,15 +11,27 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from castepkit.switch import create_switch_file
+import re
 
 
-def _parse_assignments(values: list[str]) -> dict[str, str]:
-    result: dict[str, str] = {}
+def _parse_key(key: str):
+    match = re.match(r"^([A-Za-z]+)(?:\[(\d+)\]|:(\d+))?$", key)
+    if match:
+        element = match.group(1)
+        idx = match.group(2) or match.group(3)
+        if idx is not None:
+            return (element, int(idx))
+        return element
+    return key
+
+
+def _parse_assignments(values: list[str]) -> dict:
+    result: dict = {}
     for item in values:
         if "=" not in item:
             raise argparse.ArgumentTypeError("Expected NAME=VALUE")
         key, val = item.split("=", 1)
-        result[key] = val
+        result[_parse_key(key)] = val
     return result
 
 

--- a/src/castepkit/switch.py
+++ b/src/castepkit/switch.py
@@ -7,12 +7,137 @@ from castep_outputs import parse_cell_param_file
 __all__ = ["create_switch_file"]
 
 
-def _lookup(key, mapping):
-    if key in mapping:
-        return mapping[key]
-    if isinstance(key, tuple) and key[0] in mapping:
-        return mapping[key[0]]
-    raise KeyError(f"Missing entry for {key}")
+# Covalent radii in angstrom extracted from the ``mendeleev`` package.
+# Values cover all elements up to Z=118.
+DEFAULT_RADII: dict[str, float] = {
+    "H": 0.32,
+    "He": 0.46,
+    "Li": 1.33,
+    "Be": 1.02,
+    "B": 0.85,
+    "C": 0.75,
+    "N": 0.71,
+    "O": 0.63,
+    "F": 0.64,
+    "Ne": 0.67,
+    "Na": 1.55,
+    "Mg": 1.39,
+    "Al": 1.26,
+    "Si": 1.16,
+    "P": 1.11,
+    "S": 1.03,
+    "Cl": 0.99,
+    "Ar": 0.96,
+    "K": 1.96,
+    "Ca": 1.71,
+    "Sc": 1.48,
+    "Ti": 1.36,
+    "V": 1.34,
+    "Cr": 1.22,
+    "Mn": 1.19,
+    "Fe": 1.16,
+    "Co": 1.11,
+    "Ni": 1.1,
+    "Cu": 1.12,
+    "Zn": 1.18,
+    "Ga": 1.24,
+    "Ge": 1.21,
+    "As": 1.21,
+    "Se": 1.16,
+    "Br": 1.14,
+    "Kr": 1.17,
+    "Rb": 2.1,
+    "Sr": 1.85,
+    "Y": 1.63,
+    "Zr": 1.54,
+    "Nb": 1.47,
+    "Mo": 1.38,
+    "Tc": 1.28,
+    "Ru": 1.25,
+    "Rh": 1.25,
+    "Pd": 1.2,
+    "Ag": 1.28,
+    "Cd": 1.36,
+    "In": 1.42,
+    "Sn": 1.4,
+    "Sb": 1.4,
+    "Te": 1.36,
+    "I": 1.33,
+    "Xe": 1.31,
+    "Cs": 2.32,
+    "Ba": 1.96,
+    "La": 1.8,
+    "Ce": 1.63,
+    "Pr": 1.76,
+    "Nd": 1.74,
+    "Pm": 1.73,
+    "Sm": 1.72,
+    "Eu": 1.68,
+    "Gd": 1.69,
+    "Tb": 1.68,
+    "Dy": 1.67,
+    "Ho": 1.66,
+    "Er": 1.65,
+    "Tm": 1.64,
+    "Yb": 1.7,
+    "Lu": 1.62,
+    "Hf": 1.52,
+    "Ta": 1.46,
+    "W": 1.37,
+    "Re": 1.31,
+    "Os": 1.29,
+    "Ir": 1.22,
+    "Pt": 1.23,
+    "Au": 1.24,
+    "Hg": 1.33,
+    "Tl": 1.44,
+    "Pb": 1.44,
+    "Bi": 1.51,
+    "Po": 1.45,
+    "At": 1.47,
+    "Rn": 1.42,
+    "Fr": 2.23,
+    "Ra": 2.01,
+    "Ac": 1.86,
+    "Th": 1.75,
+    "Pa": 1.69,
+    "U": 1.7,
+    "Np": 1.71,
+    "Pu": 1.72,
+    "Am": 1.66,
+    "Cm": 1.66,
+    "Bk": 1.68,
+    "Cf": 1.68,
+    "Es": 1.65,
+    "Fm": 1.67,
+    "Md": 1.73,
+    "No": 1.76,
+    "Lr": 1.61,
+    "Rf": 1.57,
+    "Db": 1.49,
+    "Sg": 1.43,
+    "Bh": 1.41,
+    "Hs": 1.34,
+    "Mt": 1.29,
+    "Ds": 1.28,
+    "Rg": 1.21,
+    "Cn": 1.22,
+    "Nh": 1.36,
+    "Fl": 1.43,
+    "Mc": 1.62,
+    "Lv": 1.75,
+    "Ts": 1.65,
+    "Og": 1.57,
+}
+
+
+def _get(mapping: dict, atom, element, default=None):
+    """Return mapping value for ``atom`` or ``element`` with fallback to ``default``."""
+    if atom in mapping:
+        return mapping[atom]
+    if element in mapping:
+        return mapping[element]
+    return default
 
 
 def create_switch_file(
@@ -29,12 +154,14 @@ def create_switch_file(
     fn_cell : str or Path
         Path to the CASTEP ``.cell`` file.
     radius_dict : dict
-        Mapping from atom label to cutting radius in angstrom.
-        Keys can be element symbols (e.g. ``"Ga"``) or tuples like
-        ``("Ga", 1)`` matching the ``positions_frac`` keys returned by
+        Mapping from atom label to cutting radius in angstrom. Entries
+        override the built-in :data:`DEFAULT_RADII` table. Keys can be
+        element symbols (e.g. ``"Ga"``) or tuples like ``("Ga", 1)`` matching
+        the ``positions_frac`` keys returned by
         :func:`castep_outputs.parse_cell_param_file`.
     cut_dict : dict
         Mapping from atom label to the action ``"keep"`` or ``"cut"``.
+        Unspecified atoms default to ``"keep"``.
     fn_switch : str or Path, optional
         Output file name. Defaults to ``<prefix>.switch`` where ``prefix`` is
         derived from ``fn_cell``.
@@ -57,7 +184,9 @@ def create_switch_file(
     lines = ["%BLOCK ATOM_DOMAIN"]
     for atom in atoms:
         element = atom[0] if isinstance(atom, tuple) else atom
-        radius = _lookup(atom, radius_dict)
+        radius = _get(radius_dict, atom, element, DEFAULT_RADII.get(element))
+        if radius is None:
+            raise KeyError(f"Missing radius for {atom}")
         radius_str = str(radius)
         if isinstance(radius, (int, float)):
             radius_str = f"{radius}d0"
@@ -69,7 +198,7 @@ def create_switch_file(
     lines.append("%BLOCK CUT_ATOM")
     for atom in atoms:
         element = atom[0] if isinstance(atom, tuple) else atom
-        action = _lookup(atom, cut_dict)
+        action = _get(cut_dict, atom, element, "keep")
         if isinstance(action, bool) or isinstance(action, int):
             action = "keep" if bool(action) else "cut"
         lines.append(f"{element}      {action} 2")

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -39,6 +39,19 @@ def test_create_switch_file(tmp_gaas):
     assert out.read_text().strip().splitlines() == expected
 
 
+def test_create_switch_defaults(tmp_gaas):
+    cell = tmp_gaas / "GaAs_Optics.cell"
+    radius = {"Ga": 0.79}
+    cut = {"As": "cut"}
+    out = create_switch_file(cell, radius, cut)
+    lines = out.read_text().strip().splitlines()
+    from castepkit.switch import DEFAULT_RADII
+    assert "Ga 0.79d0" in lines
+    assert f"As {DEFAULT_RADII['As']}d0" in lines
+    assert "Ga      keep 2" in lines
+    assert "As      cut 2" in lines
+
+
 def test_switch_cli(tmp_gaas):
     cell = tmp_gaas / "GaAs_Optics.cell"
     script = Path(__file__).resolve().parents[1] / "src" / "castepkit" / "scripts" / "create_switch.py"
@@ -54,6 +67,22 @@ def test_switch_cli(tmp_gaas):
         "Ga=keep",
         "--cut",
         "As=cut",
+    ]
+    subprocess.run(cmd, check=True)
+    assert (tmp_gaas / "GaAs_Optics.switch").is_file()
+
+
+def test_switch_cli_index(tmp_gaas):
+    cell = tmp_gaas / "GaAs_Optics.cell"
+    script = Path(__file__).resolve().parents[1] / "src" / "castepkit" / "scripts" / "create_switch.py"
+    cmd = [
+        sys.executable,
+        str(script),
+        str(cell),
+        "--radius",
+        "Ga[1]=0.79",
+        "--cut",
+        "As[1]=cut",
     ]
     subprocess.run(cmd, check=True)
     assert (tmp_gaas / "GaAs_Optics.switch").is_file()


### PR DESCRIPTION
## Summary
- include covalent radii defaults for all elements
- allow per-atom indexing in `castepkit-switch`
- fallback to default radii and keep action when unspecified
- adjust dummy scripts to satisfy linter
- add tests for new defaults and CLI behaviour

## Testing
- `ruff check . --fix`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850ed2e9fcc8325bfb8746a35843174