### PR TITLE
Check environment modules for real executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ castepkit-dens shg GaAs_Optics --scissors 0.8 --direction 111
 
 ---
 
+When running the real executables for `castepkit-cut` and `castepkit-dens`, the
+Intel compiler and MPI modules must be loaded:
+
+```bash
+module load compiler/intel/2021.3.0 mpi/intelmpi/2021.3.0
+```
+
+The configuration loader checks for these modules and prints a warning if they
+are missing.
+
+---
+
 ## License
 
 `castepkit` is distributed under the terms of the [GNU General Public License v3](https://www.gnu.org/licenses/gpl-3.0.html).

--- a/src/castepkit/config.py
+++ b/src/castepkit/config.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+import subprocess
 from pathlib import Path
 
 import toml
@@ -7,7 +8,42 @@ from platformdirs import user_config_dir
 
 CONFIG_PATH = Path(user_config_dir("castepkit")) / "config.toml"
 
-__all__ = ["load_config", "get_exec_path", "use_mpi", "get_nproc", "get_env_vars"]
+__all__ = [
+    "load_config",
+    "get_exec_path",
+    "use_mpi",
+    "get_nproc",
+    "get_env_vars",
+]
+
+_MODULES = ["compiler/intel/2021.3.0", "mpi/intelmpi/2021.3.0"]
+_MODULES_CHECKED = False
+
+
+def _check_required_modules() -> None:
+    """Verify the Intel compiler and MPI modules are loaded."""
+    global _MODULES_CHECKED
+    if _MODULES_CHECKED:
+        return
+    _MODULES_CHECKED = True
+
+    try:
+        for mod in _MODULES:
+            result = subprocess.run(
+                ["module", "is-loaded", mod],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                raise RuntimeError
+    except FileNotFoundError:
+        print("WARNING: 'module' command not found. Unable to verify loaded modules.")
+    except RuntimeError:
+        mods = " ".join(_MODULES)
+        print(
+            f"WARNING: Required modules not loaded: {mods}.\n"
+            "Please run 'module load " + mods + "' before using castepkit-cut or castepkit-dens."
+        )
 
 
 def load_config():
@@ -23,19 +59,24 @@ def get_exec_path(name: str) -> str:
 
     # Use configured path if it exists or is on PATH
     if Path(path).is_file() or shutil.which(path):
-        return path
+        final_path = path
+    else:
+        # Fall back to bundled dummy script within the package
+        dummy = Path(__file__).parent / "dummy_bin" / f"{name}.py"
+        if dummy.is_file():
+            final_path = str(dummy)
+        else:
+            # Also check for a repository-level dummy program (for tests)
+            repo_dummy = Path(__file__).resolve().parents[2] / "dummy_bin" / f"{name}.py"
+            if repo_dummy.is_file():
+                final_path = str(repo_dummy)
+            else:
+                final_path = path
 
-    # Fall back to bundled dummy script within the package
-    dummy = Path(__file__).parent / "dummy_bin" / f"{name}.py"
-    if dummy.is_file():
-        return str(dummy)
+    if name in {"atom_cutting", "weighted_den"} and "dummy_bin" not in str(final_path):
+        _check_required_modules()
 
-    # Also check for a repository-level dummy program (for tests)
-    repo_dummy = Path(__file__).resolve().parents[2] / "dummy_bin" / f"{name}.py"
-    if repo_dummy.is_file():
-        return str(repo_dummy)
-
-    return path
+    return final_path
 
 
 def use_mpi() -> bool:


### PR DESCRIPTION
## Summary
- warn if intel compiler and MPI modules are missing when running real programs
- mention module requirement in the README

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850f9de5cdc8325b11a813553c4b388